### PR TITLE
Allow admin user to configure site languages on the portal

### DIFF
--- a/src/SportsHub.Business.Tests/Services/LanguageServiceTests.cs
+++ b/src/SportsHub.Business.Tests/Services/LanguageServiceTests.cs
@@ -1,0 +1,253 @@
+﻿using Moq;
+using SportsHub.Business.Repositories;
+using SportsHub.Business.Services;
+using SportsHub.Shared.Entities;
+using SportsHub.Shared.Models;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SportsHub.Business.Tests.Services
+{
+    public class LanguageServiceTests
+    {
+        private readonly Mock<ILanguageRepository> _repository;
+        private readonly ILanguageService _service;
+
+        public LanguageServiceTests()
+        {
+            _repository = new Mock<ILanguageRepository>();
+            _service = new LanguageService(_repository.Object);
+        }
+
+        [Fact]
+        public async Task GetLanguagesAsync_ReturnsExpectedLanguages()
+        {
+            // Arrange
+            var expectedLanguages = GetLanguages();
+
+            _repository.Setup(repository => repository.GetLanguagesAsync())
+                .ReturnsAsync(expectedLanguages);
+
+            // Act
+            var actualLanguages = await _service.GetLanguagesAsync();
+
+            // Assert
+            Assert.Equal(expectedLanguages, actualLanguages);
+        }
+
+        [Fact]
+        public async Task GetLanguageByIdAsync_WhenIdIsValid_ReturnsExpectedLanguage()
+        {
+            // Arrange
+            var expectedLanguageId = Guid.NewGuid();
+
+            var expectedLanguage = new Language { Name = "Name", Code = "Code" };
+            expectedLanguage.Id = expectedLanguageId;
+
+            _repository.Setup(repository => repository.GetLanguageByIdAsync(expectedLanguageId))
+                .ReturnsAsync(expectedLanguage);
+
+            // Act
+            var actualLanguage = await _service.GetLanguageByIdAsync(expectedLanguageId);
+
+            // Assert
+            Assert.Equal(expectedLanguage.Name, actualLanguage.Name);
+            Assert.Equal(expectedLanguage.Code, actualLanguage.Code);
+            Assert.Equal(expectedLanguage.Id, actualLanguage.Id);
+        }
+
+        [Fact]
+        public async Task CreateLanguageAsync_CallsAppropriateRepositoryMethodWithParameters()
+        {
+            // Arrange
+            var expectedLanguageName = "Name";
+            var expectedLanguageCode = "Code";
+
+            // Act
+            await _service.CreateLanguageAsync(expectedLanguageName, expectedLanguageCode);
+
+            // Assert
+            _repository.Verify(repository => repository.AddLanguageAsync(It.Is<Language>(language => language.Name == expectedLanguageName && language.Code == expectedLanguageCode)));
+        }
+
+        [Fact]
+        public async Task EditLanguageAsync_CallsAppropriateRepositoryMethodWithParameters()
+        {
+            // Arrange
+            var expectedLanguageId = Guid.NewGuid();
+            var expectedLanguageName = "Name";
+            var expectedLanguageCode = "Code";
+            var expectedIsDefault = false;
+            var expectedIsHidden = true;
+            var expectedIsAdded = false;
+
+            EditLanguageModel languageModel = new()
+            {
+                Id = expectedLanguageId,
+                Name = expectedLanguageName,
+                Code = expectedLanguageCode,
+                IsDefault = expectedIsDefault,
+                IsHidden = expectedIsHidden,
+                IsAdded = expectedIsAdded
+            };
+
+            // Act
+            await _service.EditLanguageAsync(languageModel);
+
+            // Assert
+            _repository.Verify(repository => repository.EditLanguageAsync(It.Is<Language>(language =>
+                (language.Id == expectedLanguageId)
+                && (language.Name == expectedLanguageName)
+                && (language.Code == expectedLanguageCode)
+                && (language.IsDefault == expectedIsDefault)
+                && (language.IsHidden == expectedIsHidden)
+                && (language.IsAdded == expectedIsAdded))));
+        }
+
+        [Fact]
+        public async Task DeleteLanguageAsync_WhenIdIsValid_ReturnsExpectedLanguage()
+        {
+            // Arrange
+            var expectedLanguageId = Guid.NewGuid();
+            var expectedLanguageName = "Name";
+            var expectedLanguageCode = "Code";
+            var expectedIsDefault = false;
+            var expectedIsHidden = true;
+            var expectedIsAdded = false;
+
+            Language expectedLanguage = new()
+            {
+                Id = expectedLanguageId,
+                Name = expectedLanguageName,
+                Code = expectedLanguageCode,
+                IsDefault = expectedIsDefault,
+                IsHidden = expectedIsHidden,
+                IsAdded = expectedIsAdded
+            };
+
+            _repository.Setup(repository => repository.DeleteLanguageAsync(expectedLanguageId))
+                .ReturnsAsync(expectedLanguage);
+
+            // Act
+            var actualLanguage = await _service.DeleteLanguageAsync(expectedLanguageId);
+
+            // Assert
+            Assert.Equal(expectedLanguage.Id, actualLanguage.Id);
+            Assert.Equal(expectedLanguage.Name, actualLanguage.Name);
+            Assert.Equal(expectedLanguage.Code, actualLanguage.Code);
+            Assert.Equal(expectedLanguage.IsDefault, actualLanguage.IsDefault);
+            Assert.Equal(expectedLanguage.IsHidden, actualLanguage.IsHidden);
+            Assert.Equal(expectedLanguage.IsAdded, actualLanguage.IsAdded);
+        }
+
+        [Fact]
+        public async Task DoesLanguageAlreadyExistByNameAsync_WhenLanguageExists_ReturnsTrue()
+        {
+            // Arrange
+            var languageName = "Name";
+
+            _repository.Setup(repository => repository.DoesLanguageAlreadyExistByNameAsync(languageName))
+                .ReturnsAsync(true);
+
+            // Act
+            var result = await _service.DoesLanguageAlreadyExistByNameAsync(languageName);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task DoesLanguageAlreadyExistByNameAsync_WhenLanguageDoesNotExist_ReturnsFalse()
+        {
+            // Arrange
+            var languageName = "Name";
+
+            _repository.Setup(repository => repository.DoesLanguageAlreadyExistByNameAsync(languageName))
+                .ReturnsAsync(false);
+
+            // Act
+            var result = await _service.DoesLanguageAlreadyExistByNameAsync(languageName);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task DoesLanguageAlreadyExistByCodeAsync_WhenLanguageExists_ReturnsTrue()
+        {
+            // Arrange
+            var languageCode = "Code";
+
+            _repository.Setup(repository => repository.DoesLanguageAlreadyExistByCodeAsync(languageCode))
+                .ReturnsAsync(true);
+
+            // Act
+            var result = await _service.DoesLanguageAlreadyExistByCodeAsync(languageCode);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task DoesLanguageAlreadyExistByCodeAsync_WhenLanguageDoesNotExist_ReturnsFalse()
+        {
+            // Arrange
+            var languageCode = "Code";
+
+            _repository.Setup(repository => repository.DoesLanguageAlreadyExistByCodeAsync(languageCode))
+                .ReturnsAsync(false);
+
+            // Act
+            var result = await _service.DoesLanguageAlreadyExistByCodeAsync(languageCode);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task DoesLanguageAlreadyExistByIdAsync_WhenLanguageExists_ReturnsTrue()
+        {
+            // Arrange
+            var languageId = Guid.NewGuid();
+
+            _repository.Setup(repository => repository.DoesLanguageAlreadyExistByIdAsync(languageId))
+                .ReturnsAsync(true);
+
+            // Act
+            var result = await _service.DoesLanguageAlreadyExistByIdAsync(languageId);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task DoesLanguageAlreadyExistByIdAsync_WhenLanguageDoesNotExist_ReturnsFalse()
+        {
+            // Arrange
+            var languageId = Guid.NewGuid();
+
+            _repository.Setup(repository => repository.DoesLanguageAlreadyExistByIdAsync(languageId))
+                .ReturnsAsync(false);
+
+            // Act
+            var result = await _service.DoesLanguageAlreadyExistByIdAsync(languageId);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        private IEnumerable<Language> GetLanguages()
+        {
+            IEnumerable<Language> languages = new List<Language>
+            {
+                new Language { Name = "Name1", Code = "Code1" },
+                new Language { Name = "Name2", Code = "Code2" },
+                new Language { Name = "Name3", Code = "Code3" }
+            };
+
+            return languages;
+        }
+    }
+}

--- a/src/SportsHub.Business.Tests/Services/LanguageServiceTests.cs
+++ b/src/SportsHub.Business.Tests/Services/LanguageServiceTests.cs
@@ -64,9 +64,10 @@ namespace SportsHub.Business.Tests.Services
             // Arrange
             var expectedLanguageName = "Name";
             var expectedLanguageCode = "Code";
+            var languageModel = new CreateLanguageModel{ Name = expectedLanguageName, Code = expectedLanguageCode };
 
             // Act
-            await _service.CreateLanguageAsync(expectedLanguageName, expectedLanguageCode);
+            await _service.CreateLanguageAsync(languageModel);
 
             // Assert
             _repository.Verify(repository => repository.AddLanguageAsync(It.Is<Language>(language => language.Name == expectedLanguageName && language.Code == expectedLanguageCode)));

--- a/src/SportsHub.Business/Extensions/ServiceCollectionExtensions.cs
+++ b/src/SportsHub.Business/Extensions/ServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ namespace SportsHub.Extensions
             services.AddScoped<ISubcategoryService, SubcategoryService>();
             services.AddScoped<ITeamService, TeamService>();
             services.AddScoped<IArticleService, ArticleService>();
+            services.AddScoped<ILanguageService, LanguageService>();
 
             return services;
         }

--- a/src/SportsHub.Business/Repositories/ILanguageRepository.cs
+++ b/src/SportsHub.Business/Repositories/ILanguageRepository.cs
@@ -23,6 +23,5 @@ namespace SportsHub.Business.Repositories
         Task<bool> DoesLanguageAlreadyExistByCodeAsync(string languageCode);
 
         Task<bool> DoesLanguageAlreadyExistByIdAsync(Guid id);
-
     }
 }

--- a/src/SportsHub.Business/Repositories/ILanguageRepository.cs
+++ b/src/SportsHub.Business/Repositories/ILanguageRepository.cs
@@ -1,0 +1,28 @@
+﻿using SportsHub.Shared.Entities;
+
+namespace SportsHub.Business.Repositories
+{
+    public interface ILanguageRepository
+    {
+        Task<IEnumerable<Language>> GetLanguagesAsync();
+
+        Task<Language> GetLanguageByIdAsync(Guid id);
+
+        Task<Language> GetLanguageByNameAsync(string languageName);
+
+        Task<Language> GetLanguageByCodeAsync(string languageCode);
+
+        Task AddLanguageAsync(Language language);
+
+        Task EditLanguageAsync(Language language);
+
+        Task<Language> DeleteLanguageAsync(Guid id);
+
+        Task<bool> DoesLanguageAlreadyExistByNameAsync(string languageName);
+
+        Task<bool> DoesLanguageAlreadyExistByCodeAsync(string languageCode);
+
+        Task<bool> DoesLanguageAlreadyExistByIdAsync(Guid id);
+
+    }
+}

--- a/src/SportsHub.Business/Services/Abstraction/ILanguageService.cs
+++ b/src/SportsHub.Business/Services/Abstraction/ILanguageService.cs
@@ -9,7 +9,7 @@ namespace SportsHub.Business.Services
 
         Task<Language> GetLanguageByIdAsync(Guid id);
 
-        Task CreateLanguageAsync(string languageName, string languageCode);
+        Task CreateLanguageAsync(CreateLanguageModel createLanguageModel);
 
         Task EditLanguageAsync(EditLanguageModel editLanguageModel);
         

--- a/src/SportsHub.Business/Services/Abstraction/ILanguageService.cs
+++ b/src/SportsHub.Business/Services/Abstraction/ILanguageService.cs
@@ -1,0 +1,28 @@
+﻿using SportsHub.Shared.Entities;
+using SportsHub.Shared.Models;
+
+namespace SportsHub.Business.Services
+{
+    public interface ILanguageService
+    {
+        Task<IEnumerable<Language>> GetLanguagesAsync();
+
+        Task<Language> GetLanguageByIdAsync(Guid id);
+
+        Task CreateLanguageAsync(string languageName, string languageCode);
+
+        Task EditLanguageAsync(EditLanguageModel editLanguageModel);
+        
+        Task<Language> DeleteLanguageAsync(Guid Id);
+
+        Task<Guid> GetLanguageIdByNameAsync(string languageName);
+
+        Task<Guid> GetLanguageIdByCodeAsync(string languageCode);
+
+        Task<bool> DoesLanguageAlreadyExistByNameAsync(string languageName);
+
+        Task<bool> DoesLanguageAlreadyExistByCodeAsync(string languageCode);
+
+        Task<bool> DoesLanguageAlreadyExistByIdAsync(Guid id);
+    }
+}

--- a/src/SportsHub.Business/Services/Implementation/LanguageService.cs
+++ b/src/SportsHub.Business/Services/Implementation/LanguageService.cs
@@ -23,9 +23,18 @@ namespace SportsHub.Business.Services
             return await _languageRepository.GetLanguageByIdAsync(id);
         }
 
-        public async Task CreateLanguageAsync(string languageName, string languageCode)
+        public async Task CreateLanguageAsync(CreateLanguageModel createLanguageModel)
         {
-            await _languageRepository.AddLanguageAsync(new Language { Name = languageName, Code = languageCode });
+            var languageModel = new Language
+            {
+                Name = createLanguageModel.Name,
+                Code = createLanguageModel.Code,
+                IsDefault = createLanguageModel.IsDefault,
+                IsHidden = createLanguageModel.IsHidden,
+                IsAdded = createLanguageModel.IsAdded
+            };
+
+            await _languageRepository.AddLanguageAsync(languageModel);
         }
 
         public async Task EditLanguageAsync(EditLanguageModel editLanguageModel)

--- a/src/SportsHub.Business/Services/Implementation/LanguageService.cs
+++ b/src/SportsHub.Business/Services/Implementation/LanguageService.cs
@@ -1,0 +1,94 @@
+﻿using SportsHub.Business.Repositories;
+using SportsHub.Shared.Entities;
+using SportsHub.Shared.Models;
+
+namespace SportsHub.Business.Services
+{
+    public class LanguageService : ILanguageService
+    {
+        private readonly ILanguageRepository _languageRepository;
+
+        public LanguageService(ILanguageRepository languageRepository)
+        {
+            _languageRepository = languageRepository ?? throw new ArgumentNullException(nameof(languageRepository));
+        }
+
+        public async Task<IEnumerable<Language>> GetLanguagesAsync()
+        {
+            return await _languageRepository.GetLanguagesAsync();
+        }
+
+        public async Task<Language> GetLanguageByIdAsync(Guid id)
+        {
+            return await _languageRepository.GetLanguageByIdAsync(id);
+        }
+
+        public async Task CreateLanguageAsync(string languageName, string languageCode)
+        {
+            await _languageRepository.AddLanguageAsync(new Language { Name = languageName, Code = languageCode });
+        }
+
+        public async Task EditLanguageAsync(EditLanguageModel editLanguageModel)
+        {
+            var languageModel = new Language
+            {
+                Id = editLanguageModel.Id,
+                Name = editLanguageModel.Name,
+                Code = editLanguageModel.Code,
+                IsDefault = editLanguageModel.IsDefault,
+                IsHidden = editLanguageModel.IsHidden,
+                IsAdded = editLanguageModel.IsAdded
+            };
+
+            await _languageRepository.EditLanguageAsync(languageModel);
+        }
+
+        public async Task<Language> DeleteLanguageAsync(Guid id)
+        {
+            return await _languageRepository.DeleteLanguageAsync(id);
+        }
+
+        public async Task<Guid> GetLanguageIdByNameAsync(string languageName)
+        {
+            var language = await _languageRepository.GetLanguageByNameAsync(languageName);
+
+            if (language == null)
+            {
+                return Guid.Empty;
+            }
+            else
+            {
+                return language.Id;
+            }
+        }
+
+        public async Task<Guid> GetLanguageIdByCodeAsync(string languageCode)
+        {
+            var language = await _languageRepository.GetLanguageByCodeAsync(languageCode);
+
+            if (language == null)
+            {
+                return Guid.Empty;
+            }
+            else
+            {
+                return language.Id;
+            }
+        }
+
+        public async Task<bool> DoesLanguageAlreadyExistByNameAsync(string languageName)
+        {
+            return await _languageRepository.DoesLanguageAlreadyExistByNameAsync(languageName);
+        }
+
+        public async Task<bool> DoesLanguageAlreadyExistByCodeAsync(string languageCode)
+        {
+            return await _languageRepository.DoesLanguageAlreadyExistByCodeAsync(languageCode);
+        }
+
+        public async Task<bool> DoesLanguageAlreadyExistByIdAsync(Guid id)
+        {
+            return await _languageRepository.DoesLanguageAlreadyExistByIdAsync(id);
+        }
+    }
+}

--- a/src/SportsHub.Infrastructure/DBContext/SportsHubDbContext.cs
+++ b/src/SportsHub.Infrastructure/DBContext/SportsHubDbContext.cs
@@ -11,6 +11,7 @@ namespace SportsHub.Infrastructure.DBContext
         public DbSet<TeamLogo> TeamLogos => Set<TeamLogo>();
         public DbSet<Article> Articles => Set<Article>();
         public DbSet<ArticleImage> Images => Set<ArticleImage>();
+        public DbSet<Language> Languages => Set<Language>();
 
         public SportsHubDbContext(DbContextOptions<SportsHubDbContext> options) : base(options) { }
 
@@ -67,6 +68,15 @@ namespace SportsHub.Infrastructure.DBContext
                 .HasOne<Article>()
                 .WithOne()
                 .HasForeignKey<ArticleImage>(articleImage => articleImage.ArticleId);
+            modelBuilder.Entity<Language>()
+                .Property(language => language.IsDefault)
+                .HasDefaultValue(false);
+            modelBuilder.Entity<Language>()
+                .Property(language => language.IsHidden)
+                .HasDefaultValue(true);
+            modelBuilder.Entity<Language>()
+                .Property(language => language.IsAdded)
+                .HasDefaultValue(false);
         }
     }
 }

--- a/src/SportsHub.Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/SportsHub.Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -20,6 +20,7 @@ namespace SportsHub.Extensions
             services.AddScoped<ITeamLogoRepository, TeamLogoRepository>();
             services.AddScoped<IArticleRepository, ArticleRepository>();
             services.AddScoped<IArticleImageRepository, ArticleImageRepository>();
+            services.AddScoped<ILanguageRepository, LanguageRepository>();
 
             return services;
         }

--- a/src/SportsHub.Infrastructure/Migrations/20220923103814_AddLanguage.Designer.cs
+++ b/src/SportsHub.Infrastructure/Migrations/20220923103814_AddLanguage.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SportsHub.Infrastructure.DBContext;
 
@@ -11,9 +12,10 @@ using SportsHub.Infrastructure.DBContext;
 namespace SportsHub.Infrastructure.Migrations
 {
     [DbContext(typeof(SportsHubDbContext))]
-    partial class SportsHubDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220923103814_AddLanguage")]
+    partial class AddLanguage
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsHub.Infrastructure/Migrations/20220923103814_AddLanguage.cs
+++ b/src/SportsHub.Infrastructure/Migrations/20220923103814_AddLanguage.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsHub.Infrastructure.Migrations
+{
+    public partial class AddLanguage : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Languages",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    Code = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    IsDefault = table.Column<bool>(type: "bit", nullable: false, defaultValue: false),
+                    IsHidden = table.Column<bool>(type: "bit", nullable: false, defaultValue: true),
+                    IsAdded = table.Column<bool>(type: "bit", nullable: false, defaultValue: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Languages", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Languages_Code",
+                table: "Languages",
+                column: "Code",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Languages_Name",
+                table: "Languages",
+                column: "Name",
+                unique: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Languages");
+        }
+    }
+}

--- a/src/SportsHub.Infrastructure/Migrations/20220925165536_AddLanguage.Designer.cs
+++ b/src/SportsHub.Infrastructure/Migrations/20220925165536_AddLanguage.Designer.cs
@@ -12,7 +12,7 @@ using SportsHub.Infrastructure.DBContext;
 namespace SportsHub.Infrastructure.Migrations
 {
     [DbContext(typeof(SportsHubDbContext))]
-    [Migration("20220923103814_AddLanguage")]
+    [Migration("20220925165536_AddLanguage")]
     partial class AddLanguage
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -136,17 +136,17 @@ namespace SportsHub.Infrastructure.Migrations
                         .IsRequired()
                         .HasColumnType("nvarchar(450)");
 
-                    b.Property<bool>("IsAdded")
+                    b.Property<bool?>("IsAdded")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("bit")
                         .HasDefaultValue(false);
 
-                    b.Property<bool>("IsDefault")
+                    b.Property<bool?>("IsDefault")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("bit")
                         .HasDefaultValue(false);
 
-                    b.Property<bool>("IsHidden")
+                    b.Property<bool?>("IsHidden")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("bit")
                         .HasDefaultValue(true);

--- a/src/SportsHub.Infrastructure/Migrations/20220925165536_AddLanguage.cs
+++ b/src/SportsHub.Infrastructure/Migrations/20220925165536_AddLanguage.cs
@@ -16,9 +16,9 @@ namespace SportsHub.Infrastructure.Migrations
                     Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
                     Name = table.Column<string>(type: "nvarchar(450)", nullable: false),
                     Code = table.Column<string>(type: "nvarchar(450)", nullable: false),
-                    IsDefault = table.Column<bool>(type: "bit", nullable: false, defaultValue: false),
-                    IsHidden = table.Column<bool>(type: "bit", nullable: false, defaultValue: true),
-                    IsAdded = table.Column<bool>(type: "bit", nullable: false, defaultValue: false)
+                    IsDefault = table.Column<bool>(type: "bit", nullable: true, defaultValue: false),
+                    IsHidden = table.Column<bool>(type: "bit", nullable: true, defaultValue: true),
+                    IsAdded = table.Column<bool>(type: "bit", nullable: true, defaultValue: false)
                 },
                 constraints: table =>
                 {

--- a/src/SportsHub.Infrastructure/Migrations/SportsHubDbContextModelSnapshot.cs
+++ b/src/SportsHub.Infrastructure/Migrations/SportsHubDbContextModelSnapshot.cs
@@ -134,17 +134,17 @@ namespace SportsHub.Infrastructure.Migrations
                         .IsRequired()
                         .HasColumnType("nvarchar(450)");
 
-                    b.Property<bool>("IsAdded")
+                    b.Property<bool?>("IsAdded")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("bit")
                         .HasDefaultValue(false);
 
-                    b.Property<bool>("IsDefault")
+                    b.Property<bool?>("IsDefault")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("bit")
                         .HasDefaultValue(false);
 
-                    b.Property<bool>("IsHidden")
+                    b.Property<bool?>("IsHidden")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("bit")
                         .HasDefaultValue(true);

--- a/src/SportsHub.Infrastructure/Repositories/LanguageRepository.cs
+++ b/src/SportsHub.Infrastructure/Repositories/LanguageRepository.cs
@@ -1,0 +1,90 @@
+﻿using Microsoft.EntityFrameworkCore;
+using SportsHub.Business.Repositories;
+using SportsHub.Infrastructure.DBContext;
+using SportsHub.Shared.Entities;
+
+namespace SportsHub.Infrastructure.Repositories
+{
+    internal class LanguageRepository : ILanguageRepository
+    {
+        readonly protected SportsHubDbContext _context;
+
+        public LanguageRepository(SportsHubDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<IEnumerable<Language>> GetLanguagesAsync()
+        {
+            return await _context.Languages.ToListAsync();
+        }
+
+        public async Task<Language> GetLanguageByIdAsync(Guid id)
+        {
+            return await _context.Languages.FindAsync(id);
+        }
+
+        public async Task<Language> GetLanguageByNameAsync(string languageName)
+        {
+            return await _context.Languages.FirstOrDefaultAsync(language => language.Name == languageName);
+        }
+
+        public async Task<Language> GetLanguageByCodeAsync(string languageCode)
+        {
+            return await _context.Languages.FirstOrDefaultAsync(language => language.Code == languageCode);
+        }
+
+        public async Task AddLanguageAsync(Language language)
+        {
+            await _context.Languages.AddAsync(language);
+
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task EditLanguageAsync(Language language)
+        {
+            var oldLanguage = await _context.Languages.FirstOrDefaultAsync(oldLanguage => oldLanguage.Id == language.Id);
+
+            oldLanguage.Name = language.Name;
+            oldLanguage.Code = language.Code;
+            oldLanguage.IsDefault = language.IsDefault;
+            oldLanguage.IsHidden = language.IsHidden;
+            oldLanguage.IsAdded = language.IsAdded;
+
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task<Language> DeleteLanguageAsync(Guid id)
+        {
+            var language = _context.Languages.Find(id);
+            if (language != null)
+            {
+                _context.Languages.Remove(language);
+                await _context.SaveChangesAsync();
+            }
+
+            return language;
+        }
+
+        public async Task<bool> DoesLanguageAlreadyExistByNameAsync(string languageName)
+        {
+            var languages = await _context.Languages.AnyAsync(language => language.Name == languageName);
+
+            return languages;
+        }
+
+        public async Task<bool> DoesLanguageAlreadyExistByCodeAsync(string languageCode)
+        {
+            var languages = await _context.Languages.AnyAsync(language => language.Code == languageCode);
+
+            return languages;
+        }
+
+        public async Task<bool> DoesLanguageAlreadyExistByIdAsync(Guid id)
+        {
+            var languages = await _context.Languages.AnyAsync(language => language.Id == id);
+
+            return languages;
+        }
+    }
+}

--- a/src/SportsHub.Shared/Entities/Language.cs
+++ b/src/SportsHub.Shared/Entities/Language.cs
@@ -18,10 +18,10 @@ namespace SportsHub.Shared.Entities
         [Required(ErrorMessage = "Language code is required.")]
         public string Code { get; set; } = string.Empty;
 
-        public bool IsDefault { get; set; } = false;
+        public bool? IsDefault { get; set; } = false;
 
-        public bool IsHidden { get; set; } = true;
+        public bool? IsHidden { get; set; } = true;
 
-        public bool IsAdded { get; set; } = false;
+        public bool? IsAdded { get; set; } = false;
     }
 }

--- a/src/SportsHub.Shared/Entities/Language.cs
+++ b/src/SportsHub.Shared/Entities/Language.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace SportsHub.Shared.Entities
+{
+    [Index(nameof(Name), IsUnique = true)]
+    [Index(nameof(Code), IsUnique = true)]
+    public class Language
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public Guid Id { get; set; }
+
+        [Required(ErrorMessage = "Language name is required.")]
+        public string Name { get; set; } = string.Empty;
+
+        [Required(ErrorMessage = "Language code is required.")]
+        public string Code { get; set; } = string.Empty;
+
+        public bool IsDefault { get; set; } = false;
+
+        public bool IsHidden { get; set; } = true;
+
+        public bool IsAdded { get; set; } = false;
+    }
+}

--- a/src/SportsHub.Shared/Models/CreateLanguageModel.cs
+++ b/src/SportsHub.Shared/Models/CreateLanguageModel.cs
@@ -6,10 +6,10 @@
 
         public string Code { get; set; } = string.Empty;
 
-        public bool IsDefault { get; set; } = false;
+        public bool? IsDefault { get; set; } = false;
 
-        public bool IsHidden { get; set; } = true;
+        public bool? IsHidden { get; set; } = true;
 
-        public bool IsAdded { get; set; } = false;
+        public bool? IsAdded { get; set; } = false;
     }
 }

--- a/src/SportsHub.Shared/Models/CreateLanguageModel.cs
+++ b/src/SportsHub.Shared/Models/CreateLanguageModel.cs
@@ -1,0 +1,15 @@
+﻿namespace SportsHub.Shared.Models
+{
+    public class CreateLanguageModel
+    {
+        public string Name { get; set; } = string.Empty;
+
+        public string Code { get; set; } = string.Empty;
+
+        public bool IsDefault { get; set; } = false;
+
+        public bool IsHidden { get; set; } = true;
+
+        public bool IsAdded { get; set; } = false;
+    }
+}

--- a/src/SportsHub.Shared/Models/EditLanguageModel.cs
+++ b/src/SportsHub.Shared/Models/EditLanguageModel.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace SportsHub.Shared.Models
+{
+    public class EditLanguageModel
+    {
+        public Guid Id { get; set; }
+
+        public string Name { get; set; } = string.Empty;
+
+        public string Code { get; set; } = string.Empty;
+
+        public bool IsDefault { get; set; } = false;
+
+        public bool IsHidden { get; set; } = true;
+
+        public bool IsAdded { get; set; } = false;
+    }
+}

--- a/src/SportsHub.Shared/Resources/Errors.Designer.cs
+++ b/src/SportsHub.Shared/Resources/Errors.Designer.cs
@@ -133,6 +133,60 @@ namespace SportsHub.Shared.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Language code cannot be empty.
+        /// </summary>
+        public static string LanguageCodeCannotBeEmpty {
+            get {
+                return ResourceManager.GetString("LanguageCodeCannotBeEmpty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Language code is not unique.
+        /// </summary>
+        public static string LanguageCodeIsNotUnique {
+            get {
+                return ResourceManager.GetString("LanguageCodeIsNotUnique", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Language does not exist.
+        /// </summary>
+        public static string LanguageDoesNotExist {
+            get {
+                return ResourceManager.GetString("LanguageDoesNotExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Language id cannot be empty.
+        /// </summary>
+        public static string LanguageIdCannotBeEmpty {
+            get {
+                return ResourceManager.GetString("LanguageIdCannotBeEmpty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Language name cannot be empty.
+        /// </summary>
+        public static string LanguageNameCannotBeEmpty {
+            get {
+                return ResourceManager.GetString("LanguageNameCannotBeEmpty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Language name is not unique.
+        /// </summary>
+        public static string LanguageNameIsNotUnique {
+            get {
+                return ResourceManager.GetString("LanguageNameIsNotUnique", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Subcategory does not exist.
         /// </summary>
         public static string SubcategoryDoesNotExist {

--- a/src/SportsHub.Shared/Resources/Errors.resx
+++ b/src/SportsHub.Shared/Resources/Errors.resx
@@ -141,6 +141,24 @@
   <data name="FileMustHaveAppropriateFormat" xml:space="preserve">
     <value>File must have appropriate format: png, jpg, svg</value>
   </data>
+  <data name="LanguageCodeCannotBeEmpty" xml:space="preserve">
+    <value>Language code cannot be empty</value>
+  </data>
+  <data name="LanguageCodeIsNotUnique" xml:space="preserve">
+    <value>Language code is not unique</value>
+  </data>
+  <data name="LanguageDoesNotExist" xml:space="preserve">
+    <value>Language does not exist</value>
+  </data>
+  <data name="LanguageIdCannotBeEmpty" xml:space="preserve">
+    <value>Language id cannot be empty</value>
+  </data>
+  <data name="LanguageNameCannotBeEmpty" xml:space="preserve">
+    <value>Language name cannot be empty</value>
+  </data>
+  <data name="LanguageNameIsNotUnique" xml:space="preserve">
+    <value>Language name is not unique</value>
+  </data>
   <data name="SubcategoryDoesNotExist" xml:space="preserve">
     <value>Subcategory does not exist</value>
   </data>

--- a/src/SportsHub.Web.Tests/Controllers/LanguagesControllerTests.cs
+++ b/src/SportsHub.Web.Tests/Controllers/LanguagesControllerTests.cs
@@ -1,0 +1,262 @@
+﻿using FluentValidation;
+using FluentValidation.Results;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using SportsHub.Business.Services;
+using SportsHub.Shared.Entities;
+using SportsHub.Shared.Models;
+using SportsHub.Shared.Resources;
+using SportsHub.Web.Controllers;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SportsHub.Web.Tests.Controllers
+{
+    public class LanguagesControllerTests
+    {
+        private readonly Mock<ILanguageService> _service;
+        private readonly Mock<IValidator<CreateLanguageModel>> _createLanguageValidator;
+        private readonly Mock<IValidator<EditLanguageModel>> _editLanguageValidator;
+        private readonly LanguagesController _controller;
+
+        public LanguagesControllerTests()
+        {
+            _service = new Mock<ILanguageService>();
+            _createLanguageValidator = new Mock<IValidator<CreateLanguageModel>>();
+            _editLanguageValidator = new Mock<IValidator<EditLanguageModel>>();
+
+            _controller = new LanguagesController(_service.Object, _createLanguageValidator.Object, _editLanguageValidator.Object);
+        }
+
+        [Fact]
+        public async Task CreateLanguage_WhenModelIsValid_ReturnsOkResult()
+        {
+            // Arrange
+            var model = new CreateLanguageModel
+            {
+                Name = "Name",
+                Code = "Code",
+            };
+            var validationResult = new ValidationResult();
+
+            _createLanguageValidator.Setup(validator => validator.ValidateAsync(model, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(validationResult);
+
+            // Act
+            var result = await _controller.CreateLanguage(model);
+
+            // Assert
+            var objectResult = Assert.IsType<OkResult>(result);
+            Assert.Equal(StatusCodes.Status200OK, objectResult.StatusCode);
+        }
+
+        [Fact]
+        public async Task CreateLanguage_WhenModelIsInvalid_ReturnsBadRequestResult()
+        {
+            // Arrange
+            var model = new CreateLanguageModel
+            {
+                Name = string.Empty
+            };
+
+            var validationFailure = new ValidationFailure(nameof(model.Name), Errors.LanguageNameCannotBeEmpty);
+            var validationResult = new ValidationResult(new[] { validationFailure });
+
+            _createLanguageValidator.Setup(validator => validator.ValidateAsync(model, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(validationResult);
+
+            // Act
+            var result = await _controller.CreateLanguage(model);
+
+            // Assert
+            var objectResult = Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Equal(StatusCodes.Status400BadRequest, objectResult.StatusCode);
+            Assert.Equal(validationFailure.ErrorMessage, objectResult.Value);
+        }
+
+        [Fact]
+        public async Task EditLanguage_WhenModelIsValid_ReturnsOkResult()
+        {
+            // Arrange
+            var model = new EditLanguageModel
+            {
+                Id = Guid.NewGuid(),
+                Name = "Name",
+                Code = "Code",
+                IsDefault = false,
+                IsHidden = true,
+                IsAdded = false,
+            };
+            var validationResult = new ValidationResult();
+
+            _editLanguageValidator.Setup(validator => validator.ValidateAsync(model, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(validationResult);
+
+            // Act
+            var result = await _controller.EditLanguage(model);
+
+            // Assert
+            var objectResult = Assert.IsType<OkResult>(result);
+            Assert.Equal(StatusCodes.Status200OK, objectResult.StatusCode);
+        }
+
+        [Fact]
+        public async Task EditLanguage_WhenModelIsInvalid_ReturnsBadRequestResult()
+        {
+            // Arrange
+            var model = new EditLanguageModel
+            {
+                Id = Guid.NewGuid(),
+                Name = "Name",
+                Code = "Code",
+                IsDefault = false,
+                IsHidden = true,
+                IsAdded = false,
+            };
+
+            var validationFailure = new ValidationFailure(nameof(model.Name), Errors.LanguageNameCannotBeEmpty);
+            var validationResult = new ValidationResult(new[] { validationFailure });
+
+            _editLanguageValidator.Setup(validator => validator.ValidateAsync(model, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(validationResult);
+
+            // Act
+            var result = await _controller.EditLanguage(model);
+
+            // Assert
+            var objectResult = Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Equal(StatusCodes.Status400BadRequest, objectResult.StatusCode);
+            Assert.Equal(validationFailure.ErrorMessage, objectResult.Value);
+        }
+
+        [Fact]
+        public async Task DeleteLanguage_WhenLanguageDoesNotExist_ReturnsNotFoundResult()
+        {
+            // Arrange
+            var languageId = Guid.NewGuid();
+
+            _service.Setup(service => service.DeleteLanguageAsync(languageId))
+                .ReturnsAsync((Language)null);
+
+            // Act
+            var result = await _controller.DeleteLanguage(languageId);
+
+            // Assert
+            var objectResult = Assert.IsType<NotFoundResult>(result);
+            Assert.Equal(StatusCodes.Status404NotFound, objectResult.StatusCode);
+        }
+
+        [Fact]
+        public async Task DeleteLanguage_WhenLanguageExists_ReturnsOkObjectResultWithArticle()
+        {
+            // Arrange
+            var expectedLanguageId = Guid.NewGuid();
+
+            var expectedLanguage = new Language()
+            {
+                Id = expectedLanguageId,
+                Name = "Name",
+                Code = "Code",
+                IsDefault = false,
+                IsHidden = true,
+                IsAdded = false
+            };
+
+            _service.Setup(service => service.DeleteLanguageAsync(expectedLanguageId))
+               .ReturnsAsync(expectedLanguage);
+
+            // Act
+            var result = await _controller.DeleteLanguage(expectedLanguageId);
+
+            // Assert
+            var objectResult = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal(StatusCodes.Status200OK, objectResult.StatusCode);
+
+            var actualLanguage = Assert.IsType<Language>(objectResult.Value);
+            Assert.Equal(expectedLanguage.Id, actualLanguage.Id);
+            Assert.Equal(expectedLanguage.Name, actualLanguage.Name);
+            Assert.Equal(expectedLanguage.Code, actualLanguage.Code);
+            Assert.Equal(expectedLanguage.IsDefault, actualLanguage.IsDefault);
+            Assert.Equal(expectedLanguage.IsHidden, actualLanguage.IsHidden);
+            Assert.Equal(expectedLanguage.IsAdded, actualLanguage.IsAdded);
+        }
+
+        [Fact]
+        public async Task GetLanguages_ReturnsOkObjectResultWithLanguages()
+        {
+            // Arrange
+            var expectedLangugaes = GetLanguages();
+
+            _service.Setup(service => service.GetLanguagesAsync())
+                .ReturnsAsync(expectedLangugaes);
+
+            // Act
+            var result = await _controller.GetLanguages();
+
+            // Assert
+            var objectResult = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal(200, objectResult.StatusCode);
+
+            var actualLanguages = Assert.IsAssignableFrom<IEnumerable<Language>>(objectResult.Value);
+            Assert.Equal(expectedLangugaes, actualLanguages);
+        }
+
+        [Fact]
+        public async Task GetLanguage_WhenLanguageDoesNotExist_ReturnsNotFoundResult()
+        {
+            // Arrange
+            var languageId = Guid.NewGuid();
+
+            _service.Setup(service => service.GetLanguageByIdAsync(languageId))
+                .ReturnsAsync((Language)null);
+
+            // Act
+            var result = await _controller.GetLanguage(languageId);
+
+            // Assert
+            var objectResult = Assert.IsType<NotFoundResult>(result);
+            Assert.Equal(StatusCodes.Status404NotFound, objectResult.StatusCode);
+        }
+
+        [Fact]
+        public async Task GetLanguage_WhenLanguageExists_ReturnsOkObjectResultWithLanguage()
+        {
+            // Arrange
+            var expectedLanguageId = Guid.NewGuid();
+
+            var expectedLanguage = new Language { Name = "Name", Code = "Code" };
+            expectedLanguage.Id = expectedLanguageId;
+
+            _service.Setup(service => service.GetLanguageByIdAsync(expectedLanguageId))
+               .ReturnsAsync(expectedLanguage);
+
+            // Act
+            var result = await _controller.GetLanguage(expectedLanguageId);
+
+            // Assert
+            var objectResult = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal(StatusCodes.Status200OK, objectResult.StatusCode);
+
+            var actualLanguage = Assert.IsType<Language>(objectResult.Value);
+            Assert.Equal(expectedLanguage.Name, actualLanguage.Name);
+            Assert.Equal(expectedLanguage.Code, actualLanguage.Code);
+            Assert.Equal(expectedLanguage.Id, actualLanguage.Id);
+        }
+
+        private IEnumerable<Language> GetLanguages()
+        {
+            IEnumerable<Language> languages = new List<Language>
+            {
+                new Language { Name = "Name1", Code = "Code1" },
+                new Language { Name = "Name2", Code = "Code2" },
+                new Language { Name = "Name3", Code = "Code3" }
+            };
+
+            return languages;
+        }
+    }
+}

--- a/src/SportsHub.Web.Tests/Validators/CreateLanguageModelValidatorTests.cs
+++ b/src/SportsHub.Web.Tests/Validators/CreateLanguageModelValidatorTests.cs
@@ -1,0 +1,122 @@
+﻿using Moq;
+using SportsHub.Business.Services;
+using SportsHub.Shared.Models;
+using SportsHub.Shared.Resources;
+using SportsHub.Web.Validators;
+using Xunit;
+
+namespace SportsHub.Web.Tests.Validators
+{
+    public class CreateLanguageModelValidatorTests
+    {
+        private readonly Mock<ILanguageService> _service;
+        private readonly CreateLanguageModelValidator _validator;
+
+        public CreateLanguageModelValidatorTests()
+        {
+            _service = new Mock<ILanguageService>();
+            _validator = new CreateLanguageModelValidator(_service.Object);
+        }
+
+        [Fact]
+        public async void CreateLanguageModel_WhenNameIsEmpty_ReturnsValidationResultWithError()
+        {
+            // Arrange
+            var language = new CreateLanguageModel
+            {
+                Name = string.Empty
+            };
+            var expectedErrorMessage = Errors.LanguageNameCannotBeEmpty;
+
+            // Act
+            var result = await _validator.ValidateAsync(language);
+
+            // Assert
+            Assert.False(result.IsValid);
+            Assert.Contains(result.Errors, error => error.ErrorMessage == expectedErrorMessage);
+        }
+
+        [Fact]
+        public async void CreateLanguageModel_WhenCodeIsEmpty_ReturnsValidationResultWithError()
+        {
+            // Arrange
+            var language = new CreateLanguageModel
+            {
+                Code = string.Empty
+            };
+            var expectedErrorMessage = Errors.LanguageCodeCannotBeEmpty;
+
+            // Act
+            var result = await _validator.ValidateAsync(language);
+
+            // Assert
+            Assert.False(result.IsValid);
+            Assert.Contains(result.Errors, error => error.ErrorMessage == expectedErrorMessage);
+        }
+
+        [Fact]
+        public async void CreateLanguageModel_WhenNameIsNotUnique_ReturnsValidationResultWithError()
+        {
+            // Arrange
+            var language = new CreateLanguageModel
+            {
+                Name = "Name"
+            };
+            var expectedErrorMessage = Errors.LanguageNameIsNotUnique;
+
+            _service.Setup(service => service.DoesLanguageAlreadyExistByNameAsync(language.Name))
+                .ReturnsAsync(true);
+
+            // Act
+            var result = await _validator.ValidateAsync(language);
+
+            // Assert
+            Assert.False(result.IsValid);
+            Assert.Contains(result.Errors, error => error.ErrorMessage == expectedErrorMessage);
+        }
+
+        [Fact]
+        public async void CreateCategoryModel_WhenCodeIsNotUnique_ReturnsValidationResultWithError()
+        {
+            // Arrange
+            var language = new CreateLanguageModel
+            {
+                Code = "Code"
+            };
+            var expectedErrorMessage = Errors.LanguageCodeIsNotUnique;
+
+            _service.Setup(service => service.DoesLanguageAlreadyExistByCodeAsync(language.Code))
+                .ReturnsAsync(true);
+
+            // Act
+            var result = await _validator.ValidateAsync(language);
+
+            // Assert
+            Assert.False(result.IsValid);
+            Assert.Contains(result.Errors, error => error.ErrorMessage == expectedErrorMessage);
+        }
+
+        [Fact]
+        public async void CreateLanguageModel_WhenModelIsValid_ReturnsSuccessValidationResult()
+        {
+            // Arrange
+            var language = new CreateLanguageModel
+            {
+                Name = "Name",
+                Code = "Code"
+            };
+
+            _service.Setup(service => service.DoesLanguageAlreadyExistByNameAsync(language.Name))
+                .ReturnsAsync(false);
+            _service.Setup(service => service.DoesLanguageAlreadyExistByCodeAsync(language.Code))
+                .ReturnsAsync(false);
+
+            // Act
+            var result = await _validator.ValidateAsync(language);
+
+            // Assert
+            Assert.True(result.IsValid);
+            Assert.Empty(result.Errors);
+        }
+    }
+}

--- a/src/SportsHub.Web.Tests/Validators/EditLanguageModelValidatorTests.cs
+++ b/src/SportsHub.Web.Tests/Validators/EditLanguageModelValidatorTests.cs
@@ -166,7 +166,6 @@ namespace SportsHub.Web.Tests.Validators
             Assert.Contains(result.Errors, error => error.ErrorMessage == expectedErrorMessage);
         }
 
-
         [Fact]
         public async void EditLanguageModel_WhenLanguageIsValid_ReturnsSuccessValidationResult()
         {
@@ -196,4 +195,3 @@ namespace SportsHub.Web.Tests.Validators
         }
     }
 }
-

--- a/src/SportsHub.Web.Tests/Validators/EditLanguageModelValidatorTests.cs
+++ b/src/SportsHub.Web.Tests/Validators/EditLanguageModelValidatorTests.cs
@@ -1,0 +1,199 @@
+﻿using Moq;
+using SportsHub.Business.Services;
+using SportsHub.Shared.Models;
+using SportsHub.Shared.Resources;
+using SportsHub.Web.Validators;
+using System;
+using Xunit;
+
+namespace SportsHub.Web.Tests.Validators
+{
+    public class EditLanguageModelValidatorTests
+    {
+        private readonly Mock<ILanguageService> _service;
+        private readonly EditLanguageModelValidator _validator;
+
+        public EditLanguageModelValidatorTests()
+        {
+            _service = new Mock<ILanguageService>();
+            _validator = new EditLanguageModelValidator(_service.Object);
+        }
+
+        [Fact]
+        public async void EditLanguageModel_WhenLanguageIdIsEmpty_ReturnsValidationResultWithError()
+        {
+            var language = new EditLanguageModel
+            {
+                Id = Guid.Empty,
+                Name = "Name",
+                Code = "Code",
+                IsDefault = false,
+                IsHidden = true,
+                IsAdded = false,
+            };
+
+            var expectedErrorMessage = Errors.LanguageIdCannotBeEmpty;
+
+            // Act
+            var result = await _validator.ValidateAsync(language);
+
+            // Assert
+            Assert.False(result.IsValid);
+            Assert.Contains(result.Errors, error => error.ErrorMessage == expectedErrorMessage);
+        }
+
+        [Fact]
+        public async void EditLanguageModel_WhenLanguageIdDoesNotExist_ReturnsValidationResultWithError()
+        {
+            var language = new EditLanguageModel
+            {
+                Id = Guid.NewGuid(),
+                Name = "Name",
+                Code = "Code",
+                IsDefault = false,
+                IsHidden = true,
+                IsAdded = false,
+            };
+
+            var expectedErrorMessage = Errors.LanguageDoesNotExist;
+
+            _service.Setup(service => service.DoesLanguageAlreadyExistByIdAsync(language.Id))
+                .ReturnsAsync(false);
+
+            // Act
+            var result = await _validator.ValidateAsync(language);
+
+            // Assert
+            Assert.False(result.IsValid);
+            Assert.Contains(result.Errors, error => error.ErrorMessage == expectedErrorMessage);
+        }
+
+        [Fact]
+        public async void EditLanguageModel_WhenLanguageNameIsEmpty_ReturnsValidationResultWithError()
+        {
+            var language = new EditLanguageModel
+            {
+                Id = Guid.NewGuid(),
+                Name = "",
+                Code = "Code",
+                IsDefault = false,
+                IsHidden = true,
+                IsAdded = false,
+            };
+
+            var expectedErrorMessage = Errors.LanguageNameCannotBeEmpty;
+
+            // Act
+            var result = await _validator.ValidateAsync(language);
+
+            // Assert
+            Assert.False(result.IsValid);
+            Assert.Contains(result.Errors, error => error.ErrorMessage == expectedErrorMessage);
+        }
+
+        [Fact]
+        public async void EditLanguageModel_WhenLanguageNameAlreadyExist_ReturnsValidationResultWithError()
+        {
+            var language = new EditLanguageModel
+            {
+                Id = Guid.NewGuid(),
+                Name = "Name",
+                Code = "Code",
+                IsDefault = false,
+                IsHidden = true,
+                IsAdded = false,
+            };
+
+            var expectedErrorMessage = Errors.LanguageNameIsNotUnique;
+
+            _service.Setup(service => service.GetLanguageIdByNameAsync(language.Name))
+                .ReturnsAsync(Guid.NewGuid());
+
+            // Act
+            var result = await _validator.ValidateAsync(language);
+
+            // Assert
+            Assert.False(result.IsValid);
+            Assert.Contains(result.Errors, error => error.ErrorMessage == expectedErrorMessage);
+        }
+
+        [Fact]
+        public async void EditLanguageModel_WhenLanguageCodeIsEmpty_ReturnsValidationResultWithError()
+        {
+            var language = new EditLanguageModel
+            {
+                Id = Guid.NewGuid(),
+                Name = "Name",
+                Code = "",
+                IsDefault = false,
+                IsHidden = true,
+                IsAdded = false,
+            };
+
+            var expectedErrorMessage = Errors.LanguageCodeCannotBeEmpty;
+
+            // Act
+            var result = await _validator.ValidateAsync(language);
+
+            // Assert
+            Assert.False(result.IsValid);
+            Assert.Contains(result.Errors, error => error.ErrorMessage == expectedErrorMessage);
+        }
+
+        [Fact]
+        public async void EditLanguageModel_WhenLanguageCodeAlreadyExist_ReturnsValidationResultWithError()
+        {
+            var language = new EditLanguageModel
+            {
+                Id = Guid.NewGuid(),
+                Name = "Name",
+                Code = "Code",
+                IsDefault = false,
+                IsHidden = true,
+                IsAdded = false,
+            };
+
+            var expectedErrorMessage = Errors.LanguageCodeIsNotUnique;
+
+            _service.Setup(service => service.GetLanguageIdByCodeAsync(language.Code))
+                .ReturnsAsync(Guid.NewGuid());
+
+            // Act
+            var result = await _validator.ValidateAsync(language);
+
+            // Assert
+            Assert.False(result.IsValid);
+            Assert.Contains(result.Errors, error => error.ErrorMessage == expectedErrorMessage);
+        }
+
+
+        [Fact]
+        public async void EditLanguageModel_WhenLanguageIsValid_ReturnsSuccessValidationResult()
+        {
+            var language = new EditLanguageModel
+            {
+                Id = Guid.NewGuid(),
+                Name = "Name",
+                Code = "Code",
+                IsDefault = false,
+                IsHidden = true,
+                IsAdded = false,
+            };
+
+            _service.Setup(service => service.DoesLanguageAlreadyExistByIdAsync(language.Id))
+                .ReturnsAsync(true);
+            _service.Setup(service => service.GetLanguageIdByNameAsync(language.Name))
+                .ReturnsAsync(Guid.Empty);
+            _service.Setup(service => service.GetLanguageIdByCodeAsync(language.Code))
+                .ReturnsAsync(Guid.Empty);
+
+            // Act
+            var result = await _validator.ValidateAsync(language);
+
+            // Assert
+            Assert.True(result.IsValid);
+            Assert.Empty(result.Errors);
+        }
+    }
+}
+

--- a/src/SportsHub.Web/Controllers/LanguagesController.cs
+++ b/src/SportsHub.Web/Controllers/LanguagesController.cs
@@ -64,7 +64,7 @@ namespace SportsHub.Web.Controllers
                 return BadRequest(validationResult.ToString());
             }
 
-            await _languageService.CreateLanguageAsync(сreateLanguageModel.Name, сreateLanguageModel.Code);
+            await _languageService.CreateLanguageAsync(сreateLanguageModel);
 
             return Ok();
         }

--- a/src/SportsHub.Web/Controllers/LanguagesController.cs
+++ b/src/SportsHub.Web/Controllers/LanguagesController.cs
@@ -1,0 +1,106 @@
+﻿using FluentValidation;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using SportsHub.Business.Services;
+using SportsHub.Security;
+using SportsHub.Shared.Models;
+
+namespace SportsHub.Web.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class LanguagesController : ControllerBase
+    {
+        private readonly ILanguageService _languageService;
+        private IValidator<CreateLanguageModel> _createLanguageModelValidator;
+        private IValidator<EditLanguageModel> _editLanguageModelValidator;
+        public LanguagesController(
+            ILanguageService languageService,
+            IValidator<CreateLanguageModel> createLanguageModelValidator,
+            IValidator<EditLanguageModel> editLanguageModelValidator)
+        {
+            _languageService = languageService ?? throw new ArgumentNullException(nameof(languageService));
+            _createLanguageModelValidator = createLanguageModelValidator ?? throw new ArgumentNullException(nameof(createLanguageModelValidator));
+            _editLanguageModelValidator = editLanguageModelValidator ?? throw new ArgumentNullException(nameof(editLanguageModelValidator));
+        }
+
+        [HttpGet]
+        [Authorize(Policies.User)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> GetLanguages()
+        {
+            return Ok(await _languageService.GetLanguagesAsync());
+        }
+
+        [HttpGet("{id}")]
+        [Authorize(Policies.User)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> GetLanguage(Guid id)
+        {
+            var category = await _languageService.GetLanguageByIdAsync(id);
+
+            return category != null
+                ? Ok(category)
+                : NotFound();
+        }
+
+        [HttpPost]
+        [Authorize(Policies.Admin)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> CreateLanguage([FromForm]CreateLanguageModel сreateLanguageModel)
+        {
+            var validationResult = await _createLanguageModelValidator.ValidateAsync(сreateLanguageModel);
+            if (!validationResult.IsValid)
+            {
+                return BadRequest(validationResult.ToString());
+            }
+
+            await _languageService.CreateLanguageAsync(сreateLanguageModel.Name, сreateLanguageModel.Code);
+
+            return Ok();
+        }
+
+        [HttpPut]
+        [Authorize(Policies.Admin)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> EditLanguage([FromForm]EditLanguageModel editLanguageModel)
+        {
+            var validationResult = await _editLanguageModelValidator.ValidateAsync(editLanguageModel);
+            if (!validationResult.IsValid)
+            {
+                return BadRequest(validationResult.Errors.Select(error => error.ErrorMessage).First());
+            }
+
+            await _languageService.EditLanguageAsync(editLanguageModel);
+
+            return Ok();
+        }
+
+        [HttpDelete("{id}")]
+        [Authorize(Policies.Admin)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> DeleteLanguage(Guid id)
+        {
+            var language = await _languageService.DeleteLanguageAsync(id);
+
+            return language != null
+                ? Ok(language)
+                : NotFound();
+        }
+    }
+}

--- a/src/SportsHub.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/src/SportsHub.Web/Extensions/ServiceCollectionExtensions.cs
@@ -83,6 +83,8 @@ namespace SportsHub.Extensions
             services.AddScoped<IValidator<CreateTeamModel>, CreateTeamModelValidator>();
             services.AddScoped<IValidator<EditTeamModel>, EditTeamModelValidator>();
             services.AddScoped<IValidator<CreateArticleModel>, CreateArticleModelValidator>();
+            services.AddScoped<IValidator<CreateLanguageModel>, CreateLanguageModelValidator>();
+            services.AddScoped<IValidator<EditLanguageModel>, EditLanguageModelValidator>();
 
             return services;
         }

--- a/src/SportsHub.Web/Validators/CreateLanguageModelValidator.cs
+++ b/src/SportsHub.Web/Validators/CreateLanguageModelValidator.cs
@@ -1,0 +1,42 @@
+﻿using FluentValidation;
+using SportsHub.Business.Services;
+using SportsHub.Shared.Models;
+using SportsHub.Shared.Resources;
+
+namespace SportsHub.Web.Validators
+{
+    public class CreateLanguageModelValidator : AbstractValidator<CreateLanguageModel>
+    {
+        private readonly ILanguageService _languageService;
+
+        public CreateLanguageModelValidator(ILanguageService languageService)
+        {
+            _languageService = languageService ?? throw new ArgumentNullException(nameof(languageService));
+
+            RuleFor(language => language.Name)
+                .NotEmpty().WithMessage(Errors.LanguageNameCannotBeEmpty)
+                .MustAsync((name, cancellation) => DoesLanguageNameIsUniqueAsync(name))
+                .WithMessage(Errors.LanguageNameIsNotUnique);
+
+
+            RuleFor(language => language.Code)
+                .NotEmpty().WithMessage(Errors.LanguageCodeCannotBeEmpty)
+                .MustAsync((code, cancellation) => DoesLanguageCodeIsUniqueAsync(code))
+                .WithMessage(Errors.LanguageCodeIsNotUnique);
+        }
+
+        private async Task<bool> DoesLanguageNameIsUniqueAsync(string languageName)
+        {
+            var result = await _languageService.DoesLanguageAlreadyExistByNameAsync(languageName);
+
+            return !result;
+        }
+
+        private async Task<bool> DoesLanguageCodeIsUniqueAsync(string languageCode)
+        {
+            var result = await _languageService.DoesLanguageAlreadyExistByCodeAsync(languageCode);
+
+            return !result;
+        }
+    }
+}

--- a/src/SportsHub.Web/Validators/EditLanguageModelValidator.cs
+++ b/src/SportsHub.Web/Validators/EditLanguageModelValidator.cs
@@ -41,8 +41,14 @@ namespace SportsHub.Web.Validators
             {
                 return true;
             }
-            else if (result == Id) { return true; }
-            else return false;
+            else if (result == Id)
+            {
+                return true;
+            }
+            else
+            { 
+                return false;
+            }
         }
 
         private async Task<bool> DoesLanguageCodeIsUniqueAsync(string languageCode, Guid Id)
@@ -53,8 +59,14 @@ namespace SportsHub.Web.Validators
             {
                 return true;
             }
-            else if (result == Id) { return true; }
-            else return false;
+            else if (result == Id)
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
         }
     }
 }

--- a/src/SportsHub.Web/Validators/EditLanguageModelValidator.cs
+++ b/src/SportsHub.Web/Validators/EditLanguageModelValidator.cs
@@ -1,0 +1,60 @@
+﻿using FluentValidation;
+using SportsHub.Business.Services;
+using SportsHub.Shared.Models;
+using SportsHub.Shared.Resources;
+
+namespace SportsHub.Web.Validators
+{
+    public class EditLanguageModelValidator : AbstractValidator<EditLanguageModel>
+    {
+        private readonly ILanguageService _languageService;
+
+        public EditLanguageModelValidator(ILanguageService languageService)
+        {
+            _languageService = languageService ?? throw new ArgumentNullException(nameof(languageService));
+
+            RuleFor(language => language.Id)
+                .NotEmpty().WithMessage(Errors.LanguageIdCannotBeEmpty)
+                .MustAsync((id, cancellation) => _languageService.DoesLanguageAlreadyExistByIdAsync(id))
+                .WithMessage(Errors.LanguageDoesNotExist);
+
+            RuleFor(language => language)
+                .MustAsync((language, cancellation) => DoesLanguageNameIsUniqueAsync(language.Name, language.Id))
+                .WithMessage(Errors.LanguageNameIsNotUnique);
+
+            RuleFor(language => language.Name)
+                .NotEmpty().WithMessage(Errors.LanguageNameCannotBeEmpty);
+
+            RuleFor(language => language)
+                .MustAsync((language, cancellation) => DoesLanguageCodeIsUniqueAsync(language.Code, language.Id))
+                .WithMessage(Errors.LanguageCodeIsNotUnique);
+
+            RuleFor(language => language.Code)
+                .NotEmpty().WithMessage(Errors.LanguageCodeCannotBeEmpty);
+        }
+
+        private async Task<bool> DoesLanguageNameIsUniqueAsync(string languageName, Guid Id)
+        {
+            var result = await _languageService.GetLanguageIdByNameAsync(languageName);
+
+            if (result == Guid.Empty)
+            {
+                return true;
+            }
+            else if (result == Id) { return true; }
+            else return false;
+        }
+
+        private async Task<bool> DoesLanguageCodeIsUniqueAsync(string languageCode, Guid Id)
+        {
+            var result = await _languageService.GetLanguageIdByCodeAsync(languageCode);
+
+            if (result == Guid.Empty)
+            {
+                return true;
+            }
+            else if (result == Id) { return true; }
+            else return false;
+        }
+    }
+}


### PR DESCRIPTION
### Summary of changes:

- add models, repositories, services, validators and controllers to allow admin to configure languages;
- covered with tests.

### [Requirements](https://github.com/dark-side/lanthanum/tree/master/sports_hub_portal/web_application_features/manage_articles/user_stories/delete_existing_article)